### PR TITLE
Extend custom metrics

### DIFF
--- a/QUERIES.md
+++ b/QUERIES.md
@@ -1,0 +1,88 @@
+# Guide to writing queries in yaml form
+
+A query in yaml consists of a top-level name, like `mssql_instance_local_time`, with three children:
+
+* `metrics`: a list of the new Prometheus gauges to register, consisting of a name, help, and labelNames
+* `query`: the mssql query to invoke to get the metrics
+* `collect`: a multi-level structure to be turned into a collect function that turns the raw output of the query into a Prometheus metric
+
+The `collect` field has the following structure:
+
+```yaml
+collect:            # Top level name
+  metrics:          # An array of metrics that match the gauges defined in the `metrics` field above; each Prometheus gauge can actually include multiple expressed metrics, though most of the time there is a one-to-one relation between gauges and metrics
+```
+
+In the `collect.metrics` array, the metric object has the following structure:
+
+* `shared_labels`: for defining labels that are shared by all the entries in that metric
+* `submetrics`: an array of submetric objects; a submetric object defines what position (in the mssql row) the metric actually comes from, as well as any labels that are specific to that submetric
+
+For instance, the following defines a single metric with no shared labels where the data is in the 0th position of the received row:
+
+```yaml
+- submetrics:
+    - position: 0
+```
+
+For another example, the following defines a single metric where each row's data will share the labels `database` (derived from the 0th column in the row) and `state` (statically set to `current`); the value of that metric will be derived from the 1st position of the received row.
+
+```yaml
+- shared_labels: 
+    - key: database
+      position: 0
+    - key: state
+      value: current 
+  submetrics:
+    - position: 1
+```
+
+Multiple submetrics may be derived from a single metric, as when a mssql query returns two values, both of which you want to forward to Prometheus as separate values:
+
+```yaml
+- submetrics:
+    - position: 0
+- submetrics:
+    - position: 1
+```
+
+For a final example, say that you had a query similar to the current `mssql_io_stall` metric in [metrics.js](metrics.js) which has one gauge that includes several separate labeled metrics. That can be expressed in the following:
+
+```yaml
+- shared_labels: 
+    - key: database
+      position: 0
+  submetrics:
+    - position: 1
+      name: read
+      additional_labels:
+        - key: type
+          value: "read"
+    - position: 2
+      name: write
+      additional_labels:
+        - key: type
+          value: "write"
+    - position: 4
+      name: queued_read
+      additional_labels:
+        - key: type
+          value: "queued_read"
+    - position: 5
+      name: queued_write
+      additional_labels:
+        - key: type
+          value: "queued_write"
+```
+
+To step through this, each of these metrics has a database label (derived from the 0th position of the row); but each row actually contains several metrics at different positions. We add additional labels on a per-metric basis (with key/value as our structure); the `name` entry of the submetric is included for debugging purposes.
+
+## Creating new queries
+
+To create and debug queries, you can add your custom queries to the file, and pass in that value on the command line to the `metrics.js` file, which will print out the query information.
+
+```bash
+CUSTOM_METRICS_PATH=./queries.yaml node ./metrics.js
+```
+
+TODO: A debugging tool would be a useful addition.

--- a/QUERIES.md
+++ b/QUERIES.md
@@ -4,24 +4,17 @@ A query in yaml consists of a top-level name, like `mssql_instance_local_time`, 
 
 * `metrics`: a list of the new Prometheus gauges to register, consisting of a name, help, and labelNames
 * `query`: the mssql query to invoke to get the metrics
-* `collect`: a multi-level structure to be turned into a collect function that turns the raw output of the query into a Prometheus metric
+* `collect`: an array of objects to be turned into a collect function that turns the raw output of the query into a Prometheus metric; these objects match the Prometheus gauges defined in the `metrics` field
 
-The `collect` field has the following structure:
+The object in the `collect` array has the following structure:
 
-```yaml
-collect:            # Top level name
-  metrics:          # An array of metrics that match the gauges defined in the `metrics` field above; each Prometheus gauge can actually include multiple expressed metrics, though most of the time there is a one-to-one relation between gauges and metrics
-```
-
-In the `collect.metrics` array, the metric object has the following structure:
-
-* `shared_labels`: for defining labels that are shared by all the entries in that metric
-* `submetrics`: an array of submetric objects; a submetric object defines what position (in the mssql row) the metric actually comes from, as well as any labels that are specific to that submetric
+* `shared_labels`: for defining labels that are shared by all the entries in that gauge
+* `metrics`: an array of objects; this object defines what position (in the mssql row) the metric actually comes from, as well as any labels that are specific to that metric
 
 For instance, the following defines a single metric with no shared labels where the data is in the 0th position of the received row:
 
 ```yaml
-- submetrics:
+- metrics:
     - position: 0
 ```
 
@@ -33,16 +26,16 @@ For another example, the following defines a single metric where each row's data
       position: 0
     - key: state
       value: current 
-  submetrics:
+  metrics:
     - position: 1
 ```
 
-Multiple submetrics may be derived from a single metric, as when a mssql query returns two values, both of which you want to forward to Prometheus as separate values:
+Multiple metrics may be derived from a single query, as when a mssql query returns two values, both of which you want to forward to Prometheus as separate values:
 
 ```yaml
-- submetrics:
+- metrics:
     - position: 0
-- submetrics:
+- metrics:
     - position: 1
 ```
 
@@ -52,7 +45,7 @@ For a final example, say that you had a query similar to the current `mssql_io_s
 - shared_labels: 
     - key: database
       position: 0
-  submetrics:
+  metrics:
     - position: 1
       name: read
       additional_labels:
@@ -75,7 +68,7 @@ For a final example, say that you had a query similar to the current `mssql_io_s
           value: "queued_write"
 ```
 
-To step through this, each of these metrics has a database label (derived from the 0th position of the row); but each row actually contains several metrics at different positions. We add additional labels on a per-metric basis (with key/value as our structure); the `name` entry of the submetric is included for debugging purposes.
+To step through this, each of these metrics has a database label (derived from the 0th position of the row); but each row actually contains several metrics at different positions. We add additional labels on a per-metric basis (with key/value as our structure); the `name` entry of the metric is included for debugging purposes.
 
 ## Creating new queries
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ For running the exporter with custom metrics, add a yaml file with the custom me
 
 `docker run -e CUSTOM_METRICS_PATH=/path/to/queries.yaml -e SERVER=192.168.56.101 -e USERNAME=SA -e PASSWORD=qkD4x3yy -e DEBUG=app -p 4000:4000 --name prometheus-mssql-exporter awaragi/prometheus-mssql-exporter`
 
+Note: CUSTOM_METRICS_PATH supports multiple yaml files if necessary; pass them all as a comma-delimited list
+
 The image supports the following environments and exposes port 4000
 
 * **SERVER** server ip or dns name (required)
 * **PORT** server port (optional defaults to 1443)
 * **USERNAME** access user (required)
 * **PASSWORD** access password (required)
-* **CUSTOM_METRICS_PATH** path to the custom metrics yaml (optional)
-* **DEBUG** comma delimited list of enabled logs (optional currently supports app and metrics)
+* **CUSTOM_METRICS_PATH** path to the custom metrics yaml or yamls (optional); pass as a single path or as a comma-delimited list of paths
+* **DEBUG** comma-delimited list of enabled logs (optional currently supports app and metrics)
 
 It is **_required_** that the specified user has the following permissions
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ Usage
 
 `docker run -e SERVER=192.168.56.101 -e USERNAME=SA -e PASSWORD=qkD4x3yy -e DEBUG=app -p 4000:4000 --name prometheus-mssql-exporter awaragi/prometheus-mssql-exporter`
 
+For running the exporter with custom metrics, add a yaml file with the custom metrics (see [queries.yaml](queries.yaml) for a sample and [QUERIES.md](QUERIES.md) for a guide), and add the path to that file:
+
+`docker run -e CUSTOM_METRICS_PATH=/path/to/queries.yaml -e SERVER=192.168.56.101 -e USERNAME=SA -e PASSWORD=qkD4x3yy -e DEBUG=app -p 4000:4000 --name prometheus-mssql-exporter awaragi/prometheus-mssql-exporter`
+
 The image supports the following environments and exposes port 4000
 
 * **SERVER** server ip or dns name (required)
 * **PORT** server port (optional defaults to 1443)
 * **USERNAME** access user (required)
 * **PASSWORD** access password (required)
+* **CUSTOM_METRICS_PATH** path to the custom metrics yaml (optional)
 * **DEBUG** comma delimited list of enabled logs (optional currently supports app and metrics)
 
 It is **_required_** that the specified user has the following permissions

--- a/custom_metrics.js
+++ b/custom_metrics.js
@@ -1,0 +1,135 @@
+/**
+ * Functions for reading and parsing yaml file as additional metric queries
+ */
+const debug = require("debug")("metrics");
+const fs = require('fs');
+const yaml = require('js-yaml');
+const client = require('prom-client');
+
+/**
+ * Function that reads and parses a yaml file into metric objects
+ *
+ * @param yaml_path the path to the yaml file
+ *
+ * @returns [Array of query-based metrics objects, Error]
+ */
+function parse_metrics(yaml_path) {
+    let metrics = []
+    let file, raw_metrics
+    try {
+        file = fs.readFileSync(yaml_path, 'utf8')
+    } catch (error) {
+        return [[], error]        
+    }
+    
+    try {
+        raw_metrics = yaml.load(file)
+    } catch (error) {
+        return [[], error]        
+    }
+
+    for (let raw_metric in raw_metrics) {
+        metrics.push(build_metric_object(raw_metrics[raw_metric]))
+    }
+
+    return [metrics, null]
+}
+
+/**
+ * Function that reads JS object and returns metric object ussable in index.js
+ *
+ * @param metric_json Metric in json form
+ * example: 
+ *  { 
+ *      metrics: [ {
+ *          name: 'mssql_instance_local_time_custom',
+ *          help: 'Number of seconds since epoch on local instance (custom version)' 
+ *      } ],
+ *      query: 'SELECT DATEDIFF(second, \'19700101\', GETUTCDATE())',
+ *      collect: { 
+ *          metrics: [ { 
+ *              submetrics: [ { position: 0 } ] 
+ *          } ]
+ *      } 
+ *  }
+ *
+ * @returns object usable by index.js; see metrics.js for examples
+ */
+function build_metric_object(metric_json) {
+    gauges_object = {}
+    for (let raw_gauge of metric_json.metrics) {
+        gauges_object[raw_gauge["name"]] = new client.Gauge(raw_gauge)
+    }
+    return {
+        metrics: gauges_object,
+        query: metric_json["query"],
+        collect: build_collect_function(metric_json)
+    }
+}
+
+/**
+ * Function that reads JS object and returns collect function
+ *
+ * @param metric_json Metric in json forml; see queries.yaml for examples and QUERIES.md for documentation
+ *
+ * @returns function
+ */
+function build_collect_function(metric_json) {
+    function collector (rows, metrics) {
+        // Metrics are returned as a series of either one or more rows
+        for (let row_pos = 0; row_pos < rows.length; row_pos++) {
+            let row = rows[row_pos];
+            // For each row, we will collect each metric, including the labels specified
+            for (let i = 0; i < metric_json.collect.metrics.length; i++) {
+                let labels = {}
+                if (metric_json.collect.metrics[i].shared_labels) {
+                    labels = add_labels(labels, metric_json.collect.metrics[i].shared_labels, row)
+                }
+                for (let position_obj of metric_json.collect.metrics[i].submetrics) {
+                    let fetched_value = row[position_obj.position].value;
+                    if (position_obj.name) {
+                        debug("Fetch ", metric_json.metrics[i].name, position_obj.name, fetched_value);
+                    } else {
+                        debug("Fetch ", metric_json.metrics[i].name, fetched_value);
+                    }
+                    if (position_obj.additional_labels) {
+                        labels = add_labels(labels, position_obj.additional_labels, row)
+                    }
+                    if (Object.keys(labels).length != 0) {
+                        metrics[metric_json.metrics[i].name].set(labels, fetched_value);
+                    } else {
+                        metrics[metric_json.metrics[i].name].set(fetched_value);
+                    }    
+                }
+            }
+        }
+    }
+
+    return collector
+}
+
+/**
+ * Function for parsing labels for metrics
+ *
+ * @param labels dictionary to add to
+ * @param raw_labels raw labels JSON
+ * @param row current MSSQL row
+ *
+ * @returns labels_return dictionary of labels (cloned from original)
+ */
+function add_labels(labels, raw_labels, row) {
+    labels_return = Object.assign({}, labels);
+    for (let label_obj of raw_labels) {
+        // Labels can either be defined or dynamically collected from the rows
+        if (label_obj.value) {
+            labels_return[label_obj.key] = label_obj.value
+        } else {
+            labels_return[label_obj.key] = row[label_obj.position].value
+        }
+    }
+    return labels_return
+}
+
+module.exports = {
+    parse_metrics: parse_metrics,
+};

--- a/custom_metrics.js
+++ b/custom_metrics.js
@@ -46,11 +46,11 @@ function parse_metrics(yaml_path) {
  *          help: 'Number of seconds since epoch on local instance (custom version)' 
  *      } ],
  *      query: 'SELECT DATEDIFF(second, \'19700101\', GETUTCDATE())',
- *      collect: { 
+ *      collect: [ { 
  *          metrics: [ { 
- *              submetrics: [ { position: 0 } ] 
- *          } ]
- *      } 
+ *              position: 0 
+ *          } ] 
+ *      } ]
  *  }
  *
  * @returns object usable by index.js; see metrics.js for examples
@@ -80,12 +80,12 @@ function build_collect_function(metric_json) {
         for (let row_pos = 0; row_pos < rows.length; row_pos++) {
             let row = rows[row_pos];
             // For each row, we will collect each metric, including the labels specified
-            for (let i = 0; i < metric_json.collect.metrics.length; i++) {
+            for (let i = 0; i < metric_json.collect.length; i++) {
                 let labels = {}
-                if (metric_json.collect.metrics[i].shared_labels) {
-                    labels = add_labels(labels, metric_json.collect.metrics[i].shared_labels, row)
+                if (metric_json.collect[i].shared_labels) {
+                    labels = add_labels(labels, metric_json.collect[i].shared_labels, row)
                 }
-                for (let position_obj of metric_json.collect.metrics[i].submetrics) {
+                for (let position_obj of metric_json.collect[i].metrics) {
                     let fetched_value = row[position_obj.position].value;
                     if (position_obj.name) {
                         debug("Fetch ", metric_json.metrics[i].name, position_obj.name, fetched_value);

--- a/metrics.js
+++ b/metrics.js
@@ -220,11 +220,13 @@ const default_metrics = [
 
 let metrics = default_metrics;
 if (process.env["CUSTOM_METRICS_PATH"]) {
-    let [custom_metrics, err] = parse_custom_metrics(process.env["CUSTOM_METRICS_PATH"])
-    if (err != null) {
-        throw new Error("Error parsing custom metrics")
+    for (let yaml_path of process.env["CUSTOM_METRICS_PATH"].split(",")) {
+        let [custom_metrics, err] = parse_custom_metrics(yaml_path)
+        if (err != null) {
+            throw new Error("Error parsing custom metrics")
+        }
+        metrics = metrics.concat(custom_metrics)
     }
-    metrics = metrics.concat(custom_metrics)
 }
 
 module.exports = {

--- a/metrics.js
+++ b/metrics.js
@@ -4,6 +4,7 @@
  */
 const debug = require("debug")("metrics");
 const client = require('prom-client');
+const parse_custom_metrics = require('./custom_metrics').parse_metrics;
 
 // UP metric
 const up = new client.Gauge({name: 'up', help: "UP Status"});
@@ -203,7 +204,7 @@ from sys.dm_os_sys_memory`,
     }
 };
 
-const metrics = [
+const default_metrics = [
     mssql_instance_local_time,
     mssql_connections,
     mssql_deadlocks,
@@ -216,6 +217,15 @@ const metrics = [
     mssql_os_process_memory,
     mssql_os_sys_memory
 ];
+
+let metrics = default_metrics;
+if (process.env["CUSTOM_METRICS_PATH"]) {
+    let [custom_metrics, err] = parse_custom_metrics(process.env["CUSTOM_METRICS_PATH"])
+    if (err != null) {
+        throw new Error("Error parsing custom metrics")
+    }
+    metrics = metrics.concat(custom_metrics)
+}
 
 module.exports = {
     client: client,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "debug": "^2.6.8",
     "express": "4.15.2",
+    "js-yaml": "4.0.0",
     "prom-client": "9.1.1",
     "tedious": "2.0.0"
   },
@@ -35,5 +36,3 @@
     "nodemon": "^1.11.0"
   }
 }
-
-

--- a/queries.yaml
+++ b/queries.yaml
@@ -1,0 +1,96 @@
+# Reading one metric with no label
+mssql_instance_local_time_custom:
+  metrics:
+    - name: "mssql_instance_local_time_custom"
+      help: "Number of seconds since epoch on local instance (custom version)"
+  query: "SELECT DATEDIFF(second, '19700101', GETUTCDATE())"
+  collect:
+    metrics:
+      - submetrics:
+          - position: 0
+
+# Reading one metric with labels
+mssql_connections_custom:
+  metrics:
+    - name: "mssql_connections_custom"
+      help: "Number of active connections (custom version)"
+      labelNames: [database, state]
+  query: "SELECT DB_NAME(sP.dbid), COUNT(sP.spid) FROM sys.sysprocesses sP GROUP BY DB_NAME(sP.dbid)"
+  collect:
+    metrics:
+      - shared_labels: 
+          - key: database
+            position: 0
+          - key: state
+            value: current 
+        submetrics:
+          - position: 1
+
+# Reading two or more metrics --
+# note the order of the `mssql_os_process_memory_custom.metrics` array matches the `mssql_os_process_memory_custom.collect.metrics` array
+mssql_os_process_memory_custom:
+  metrics:
+    - name: 'mssql_page_fault_count_custom'
+      help: 'Number of page faults since last restart (custom version)'
+    - name: 'mssql_memory_utilization_percentage_custom'
+      help: 'Percentage of memory utilization (custom version)'
+  query: "SELECT page_fault_count, memory_utilization_percentage from sys.dm_os_process_memory"
+  collect:
+    metrics:
+      - submetrics:
+          - position: 0
+      - submetrics:
+          - position: 1
+    
+# Reading two or more metrics where one of those metrics involves multiple outputs
+mssql_io_stall_custom:
+  metrics:
+    - name: 'mssql_io_stall_custom'
+      help: 'Wait time (ms) of stall since last restart (custom version)' 
+      labelNames: ['database', 'type']
+    - name: 'mssql_io_stall_total_custom'
+      help: 'Wait time (ms) of stall since last restart (custom version)' 
+      labelNames: ['database']
+  query: "SELECT
+cast(DB_Name(a.database_id) as varchar) as name,
+    max(io_stall_read_ms),
+    max(io_stall_write_ms),
+    max(io_stall),
+    max(io_stall_queued_read_ms),
+    max(io_stall_queued_write_ms)
+FROM
+sys.dm_io_virtual_file_stats(null, null) a
+INNER JOIN sys.master_files b ON a.database_id = b.database_id and a.file_id = b.file_id
+group by a.database_id"
+  collect:
+    metrics:
+      - shared_labels: 
+          - key: database
+            position: 0
+        submetrics:
+          - position: 1
+            name: read
+            additional_labels:
+              - key: type
+                value: "read"
+          - position: 2
+            name: write
+            additional_labels:
+              - key: type
+                value: "write"
+          - position: 4
+            name: queued_read
+            additional_labels:
+              - key: type
+                value: "queued_read"
+          - position: 5
+            name: queued_write
+            additional_labels:
+              - key: type
+                value: "queued_write"
+      - shared_labels: 
+          - key: database
+            position: 0
+        submetrics:
+          - position: 3
+    

--- a/queries.yaml
+++ b/queries.yaml
@@ -5,9 +5,8 @@ mssql_instance_local_time_custom:
       help: "Number of seconds since epoch on local instance (custom version)"
   query: "SELECT DATEDIFF(second, '19700101', GETUTCDATE())"
   collect:
-    metrics:
-      - submetrics:
-          - position: 0
+    - metrics:
+        - position: 0
 
 # Reading one metric with labels
 mssql_connections_custom:
@@ -17,14 +16,13 @@ mssql_connections_custom:
       labelNames: [database, state]
   query: "SELECT DB_NAME(sP.dbid), COUNT(sP.spid) FROM sys.sysprocesses sP GROUP BY DB_NAME(sP.dbid)"
   collect:
-    metrics:
-      - shared_labels: 
-          - key: database
-            position: 0
-          - key: state
-            value: current 
-        submetrics:
-          - position: 1
+    - shared_labels: 
+        - key: database
+          position: 0
+        - key: state
+          value: current 
+      metrics:
+        - position: 1
 
 # Reading two or more metrics --
 # note the order of the `mssql_os_process_memory_custom.metrics` array matches the `mssql_os_process_memory_custom.collect.metrics` array
@@ -36,11 +34,10 @@ mssql_os_process_memory_custom:
       help: 'Percentage of memory utilization (custom version)'
   query: "SELECT page_fault_count, memory_utilization_percentage from sys.dm_os_process_memory"
   collect:
-    metrics:
-      - submetrics:
-          - position: 0
-      - submetrics:
-          - position: 1
+    - metrics:
+        - position: 0
+    - metrics:
+        - position: 1
     
 # Reading two or more metrics where one of those metrics involves multiple outputs
 mssql_io_stall_custom:
@@ -63,34 +60,33 @@ sys.dm_io_virtual_file_stats(null, null) a
 INNER JOIN sys.master_files b ON a.database_id = b.database_id and a.file_id = b.file_id
 group by a.database_id"
   collect:
-    metrics:
-      - shared_labels: 
-          - key: database
-            position: 0
-        submetrics:
-          - position: 1
-            name: read
-            additional_labels:
-              - key: type
-                value: "read"
-          - position: 2
-            name: write
-            additional_labels:
-              - key: type
-                value: "write"
-          - position: 4
-            name: queued_read
-            additional_labels:
-              - key: type
-                value: "queued_read"
-          - position: 5
-            name: queued_write
-            additional_labels:
-              - key: type
-                value: "queued_write"
-      - shared_labels: 
-          - key: database
-            position: 0
-        submetrics:
-          - position: 3
+    - shared_labels: 
+        - key: database
+          position: 0
+      metrics:
+        - position: 1
+          name: read
+          additional_labels:
+            - key: type
+              value: "read"
+        - position: 2
+          name: write
+          additional_labels:
+            - key: type
+              value: "write"
+        - position: 4
+          name: queued_read
+          additional_labels:
+            - key: type
+              value: "queued_read"
+        - position: 5
+          name: queued_write
+          additional_labels:
+            - key: type
+              value: "queued_write"
+    - shared_labels: 
+        - key: database
+          position: 0
+      metrics:
+        - position: 3
     


### PR DESCRIPTION
To allow users to add new metrics on a per-deployment basis, this PR 

* Adds yaml parser to add custom metrics
* Adds documentation on yaml parser