### PR TITLE
render proper status code for easy of K8s/Pod heath check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,8 +144,7 @@ app.get("/metrics", async (req, res) => {
     const mssqlUp = entries.mssql_up.metrics.mssql_up;
     mssqlUp.set(0);
     res.header("X-Error", error.message || error);
-    res.status(404).end('Not Found');
-    res.send(client.register.getSingleMetricAsString(mssqlUp.name));
+    res.status(404).end(client.register.getSingleMetricAsString(mssqlUp.name));
   }
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ app.get("/metrics", async (req, res) => {
     const mssqlUp = entries.mssql_up.metrics.mssql_up;
     mssqlUp.set(0);
     res.header("X-Error", error.message || error);
+    res.status(404).end('Not Found');
     res.send(client.register.getSingleMetricAsString(mssqlUp.name));
   }
 });


### PR DESCRIPTION
Hi

upgrading the /metrics handler with a proper http return code where it can be queried via K8s probes (readiness/liveness) 

- in case of losing DB connection ( dynamic secrets handing or expiration ) will help us to invoke a Pod restart.